### PR TITLE
[patch] add function:findSaferVer to check version.

### DIFF
--- a/updater.js
+++ b/updater.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+var nspAPI = require('nsp-api');
 var fs = require('fs');
 var npm = require("npm");
 var request = require('request');
@@ -158,5 +159,19 @@ function testLibVersion(lib, version) {
         console.log(data);
       }
     });
+  });
+}
+
+function saferVersion(model, version, callback) {
+  nspAPI.validateModule(model, version, function (err, results) {
+    if (err) {
+      // An error generated from the underlying request.
+      console.log(err);
+    } else if (results.length !== 0) {
+      console.log("in func : %j", results);
+      return callback(false);
+    } else {
+      return callback(true);
+    }
   });
 }


### PR DESCRIPTION
there is some problems in @Piicksarn  branch, so i rewritten her branch:saferVersion.

1.coding style format

>```js
        saferVersion(model,version,safeVersions);
        console.log('in:'+safeVersions);
```

2.first i thought function name and it's args need more distinct, that will improve readability.

>```js
    saferVersion(model,version,safeVersions);
```

and why we need variable safeVersions as an input arg? i mean just return whether the version is safe or not will let function purely.

3.in function:checkVer [line : 57], why need to reassign input arg:version?

>```js
function checkVer(lib, version) {
  version = pkg.dependencies[lib];
  // ...
}
```

4.The most seriously, i found each time after i ran update.js i needed to install request again!